### PR TITLE
Sdk 0.10.23 hls

### DIFF
--- a/gst/hls/gsthlsdemux.c
+++ b/gst/hls/gsthlsdemux.c
@@ -1008,15 +1008,15 @@ gst_hls_demux_push_event (GstHLSDemux * demux, GstEvent * event)
 
   if (demux->video_srcpad->pad != NULL) {
     gst_event_ref (event);
-    ret &= gst_pad_push_event (demux->video_srcpad->in_pad, event);
+    ret &= gst_pad_push_event (demux->video_srcpad->pad, event);
   }
   if (demux->audio_srcpad->pad != NULL) {
     gst_event_ref (event);
-    ret &= gst_pad_push_event (demux->audio_srcpad->in_pad, event);
+    ret &= gst_pad_push_event (demux->audio_srcpad->pad, event);
   }
   if (demux->subtt_srcpad->pad != NULL) {
     gst_event_ref (event);
-    ret &= gst_pad_push_event (demux->subtt_srcpad->in_pad, event);
+    ret &= gst_pad_push_event (demux->subtt_srcpad->pad, event);
   }
   gst_event_unref (event);
 

--- a/gst/hls/gsthlsdemux.c
+++ b/gst/hls/gsthlsdemux.c
@@ -2801,7 +2801,7 @@ error:
   {
     if (!demux->cancelled) {
       GST_ERROR_OBJECT (demux, "Error fetching fragment");
-      gst_hls_demux_stop (demux);
+      gst_hls_demux_push_event (demux, gst_event_new_eos ());
     }
     ret = FALSE;
     goto exit;

--- a/gst/hls/gsturidownloader.c
+++ b/gst/hls/gsturidownloader.c
@@ -398,9 +398,9 @@ gst_uri_downloader_fetch_fragment (GstUriDownloader * downloader,
   downloader->priv->length = length = fragment->length;
   downloader->priv->offset = offset = fragment->offset;
 
- 	/* Have to lock it *before* setting the URI in case the result  
-   * is returned before we're ready to wait on it.  
-  */  
+  /* Have to lock it *before* setting the URI in case the result
+   * is returned before we're ready to wait on it.
+  */
   g_mutex_lock (downloader->priv->lock);
 
   if (!gst_uri_downloader_set_uri (downloader, fragment->name)) {

--- a/gst/hls/gsturidownloader.c
+++ b/gst/hls/gsturidownloader.c
@@ -361,13 +361,14 @@ gst_uri_downloader_set_uri (GstUriDownloader * downloader, const gchar * uri)
     /* add a sync handler for the bus messages to detect errors in the download */
     gst_element_set_bus (GST_ELEMENT (downloader->priv->urisrc),
         downloader->priv->bus);
-
-    pad = gst_element_get_static_pad (downloader->priv->urisrc, "src");
-    if (!pad)
-      return FALSE;
-    gst_pad_link (pad, downloader->priv->pad);
-    gst_object_unref (pad);
   }
+
+  pad = gst_element_get_static_pad (downloader->priv->urisrc, "src");
+  if (!pad)
+    return FALSE;
+  gst_pad_link (pad, downloader->priv->pad);
+  gst_object_unref (pad);
+
   gst_bus_set_sync_handler (downloader->priv->bus,
       gst_uri_downloader_bus_handler, downloader);
   gst_uri_handler_set_uri (GST_URI_HANDLER (downloader->priv->urisrc), uri);

--- a/gst/hls/gsturidownloader.c
+++ b/gst/hls/gsturidownloader.c
@@ -281,10 +281,20 @@ done:
 static void
 gst_uri_downloader_stop (GstUriDownloader * downloader)
 {
+  GstPad *pad;
+
   GST_DEBUG_OBJECT (downloader, "Stopping source element");
 
+  /* remove the bus' sync handler */
+  gst_bus_set_sync_handler (downloader->priv->bus, NULL, NULL);
+  /* unlink the source element from the internal pad */
+  pad = gst_pad_get_peer (downloader->priv->pad);
+  if (pad) {
+    gst_pad_unlink (pad, downloader->priv->pad);
+    gst_object_unref (pad);
+  }
   /* set the element state to NULL */
-  gst_element_set_state (downloader->priv->urisrc, GST_STATE_READY);
+  gst_element_set_state (downloader->priv->urisrc, GST_STATE_NULL);
   gst_element_get_state (downloader->priv->urisrc, NULL, NULL,
       GST_CLOCK_TIME_NONE);
 }


### PR DESCRIPTION
We found what (appear) to be several bugs in the hlsdemux plug-in that might interest you. We encountered these when testing with encrypted streams that utilized a EXT-X-KEY field with a URI that followed RFC 2397 rather than a more traditional URI. As a result the dataurisrc plugin was used to fetch the inline AES-128 key. This exposed a race condition. We also fixed several pad related issues.

Thanks for making your modifications to the HLS plugin available. They served as a great starting point for our efforts to get this to work reliably with in-line data URIs.
