### PR TITLE
Updated DirectX9 API to DirectX9Ex

### DIFF
--- a/sys/d3dvideosink/d3dvideosink.h
+++ b/sys/d3dvideosink/d3dvideosink.h
@@ -85,7 +85,7 @@ struct _GstD3DVideoSink
 
   GMutex *d3d_device_lock;
   LPDIRECT3DSURFACE9 d3d_offscreen_surface;
-  LPDIRECT3DDEVICE9 d3ddev;
+  LPDIRECT3DDEVICE9EX d3ddev;
   D3DPRESENT_PARAMETERS d3dpp;
 
   D3DFORMAT d3dformat;

--- a/sys/d3dvideosink/directx/directx9/dx9_d3d.c
+++ b/sys/d3dvideosink/directx/directx9/dx9_d3d.c
@@ -29,7 +29,8 @@ dx9_d3d_init (DirectXAPIComponent * component, gpointer data)
   DIRECTX_OPEN_COMPONENT_MODULE (component, "d3d9");
 
   DIRECTX_DEBUG ("Setting Direct3D dispatch table");
-  DIRECTX_OPEN_COMPONENT_SYMBOL (component, D3D9DispatchTable, Direct3DCreate9);
+  DIRECTX_OPEN_COMPONENT_SYMBOL (component, D3D9DispatchTable,
+      Direct3DCreate9Ex);
 
   //{
   //  IDirect3D9* blah;

--- a/sys/d3dvideosink/directx/directx9/dx9_d3d.h
+++ b/sys/d3dvideosink/directx/directx9/dx9_d3d.h
@@ -32,11 +32,11 @@ typedef struct _D3D9 D3D9;
 typedef struct _D3D9DispatchTable D3D9DispatchTable;
 
 /* Functions */
-typedef gpointer /* IDirect3D9* */ (WINAPI *LPDIRECT3DCREATE9) (UINT);
+typedef HRESULT  /* IDirect3D9Ex* */ (WINAPI *LPDIRECT3DCREATE9EX) (UINT,void  **);
 
 struct _D3D9DispatchTable 
 {
-  LPDIRECT3DCREATE9 Direct3DCreate9;
+  LPDIRECT3DCREATE9EX Direct3DCreate9Ex;
 };
 
 /* Global data */


### PR DESCRIPTION
Legacy Win98/XP DirectX9 doesn't properly support multi monitor
fullscreen modes, because the D3D device adquires 'exclusive' use
of the hardware and doesn't allow other devices to be created at
some stages.
Upgrading API to  DirectX9Ex solves this issue.

"Ex" version was introduced in Windows Vista, so this patch also
deprecates Windows XP support.