### PR TITLE
h264parse: Add support for stream-format=avc3

### DIFF
--- a/tests/check/elements/h264parse.c
+++ b/tests/check/elements/h264parse.c
@@ -43,6 +43,13 @@ GstStaticPadTemplate sinktemplate_avc_au = GST_STATIC_PAD_TEMPLATE ("sink",
         ", stream-format = (string) avc, alignment = (string) au")
     );
 
+GstStaticPadTemplate sinktemplate_avc3_au = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (SINK_CAPS_TMPL
+        ", stream-format = (string) avc3, alignment = (string) au")
+    );
+
 GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
@@ -65,13 +72,27 @@ static guint8 h264_pps[] = {
 };
 
 /* combines to this codec-data */
-static guint8 h264_codec_data[] = {
+static guint8 h264_avc_codec_data[] = {
   0x01, 0x4d, 0x40, 0x15, 0xff, 0xe1, 0x00, 0x17,
   0x67, 0x4d, 0x40, 0x15, 0xec, 0xa4, 0xbf, 0x2e,
   0x02, 0x20, 0x00, 0x00, 0x03, 0x00, 0x2e, 0xe6,
   0xb2, 0x80, 0x01, 0xe2, 0xc5, 0xb2, 0xc0, 0x01,
   0x00, 0x04, 0x68, 0xeb, 0xec, 0xb2
 };
+
+/* codec-data for avc3 where there are no SPS/PPS in the codec_data */
+static guint8 h264_avc3_codec_data[] = {
+  0x01,                         /* config version, always == 1 */
+  0x4d,                         /* profile */
+  0x40,                         /* profile compatibility */
+  0x15, 0xff,                   /* 6 reserved bits, lengthSizeMinusOne */
+  0xe0,                         /* 3 reserved bits, numSPS */
+  0x00                          /* numPPS */
+};
+
+static guint8 *h264_codec_data = NULL;
+static guint8 h264_codec_data_size = 0;
+
 
 /* keyframes all around */
 static guint8 h264_idrframe[] = {
@@ -209,7 +230,7 @@ GST_START_TEST (test_parse_detect_stream)
     fail_unless (val != NULL);
     buf = gst_value_get_buffer (val);
     fail_unless (buf != NULL);
-    fail_unless (GST_BUFFER_SIZE (buf) == sizeof (h264_codec_data));
+    fail_unless (GST_BUFFER_SIZE (buf) == h264_codec_data_size);
     fail_unless (memcmp (GST_BUFFER_DATA (buf), h264_codec_data,
             GST_BUFFER_SIZE (buf)) == 0);
   }
@@ -284,7 +305,7 @@ GST_START_TEST (test_parse_packetized)
   caps = gst_caps_from_string (SRC_CAPS_TMPL);
   cdata = gst_buffer_new ();
   GST_BUFFER_DATA (cdata) = h264_codec_data;
-  GST_BUFFER_SIZE (cdata) = sizeof (h264_codec_data);
+  GST_BUFFER_SIZE (cdata) = h264_codec_data_size;
   gst_caps_set_simple (caps, "codec_data", GST_TYPE_BUFFER, cdata, NULL);
   gst_buffer_unref (cdata);
   desc = gst_caps_to_string (caps);
@@ -350,6 +371,9 @@ main (int argc, char **argv)
   ctx_no_metadata = TRUE;
   ctx_codec_data = FALSE;
 
+  h264_codec_data = h264_avc_codec_data;
+  h264_codec_data_size = sizeof (h264_avc_codec_data);
+
   ctx_suite = "h264parse_to_bs_nal";
   s = h264parse_suite ();
   sr = srunner_create (s);
@@ -369,7 +393,23 @@ main (int argc, char **argv)
   nf += srunner_ntests_failed (sr);
   srunner_free (sr);
 
+  /* setup and tweak to handle avc3 au output */
+  h264_codec_data = h264_avc3_codec_data;
+  h264_codec_data_size = sizeof (h264_avc3_codec_data);
+  ctx_suite = "h264parse_to_avc3_au";
+  ctx_sink_template = &sinktemplate_avc3_au;
+  ctx_discard = 0;
+  ctx_codec_data = TRUE;
+
+  s = h264parse_suite ();
+  sr = srunner_create (s);
+  srunner_run_all (sr, CK_NORMAL);
+  nf += srunner_ntests_failed (sr);
+  srunner_free (sr);
+
   /* setup and tweak to handle avc packetized input */
+  h264_codec_data = h264_avc_codec_data;
+  h264_codec_data_size = sizeof (h264_avc_codec_data);
   ctx_suite = "h264parse_packetized";
   /* turn into separate byte stream NALs */
   ctx_sink_template = &sinktemplate_bs_nal;


### PR DESCRIPTION
When outputting in AVC3 stream format, the codec_data should not
contain any SPS or PPS, because they are embedded inside the stream.

In case of avc->bytestream h264parse will push the SPS and PPS from
codec_data downstream at the start of the stream, at intervals
controlled by "config-interval" and when there is a codec_data change.

In the case of avc3->bytstream h264parse detects that there is
already SPS/PPS in the stream and sets h264parse->push_codec to FALSE.
Therefore avc3->bytstream was already supported, except for the stream
type.

In the case of bystream->avc h264parse will generate codec_data caps
from the parsed SPS/PPS in the stream. However it does not remove these
SPS/PPS from the stream. bytestream->avc3 is the same as bytestream->avc
except that the codec_data must not have any SPS/PPS in it.

|--------------+-------------+-------------------|
|stream-format | SPS in-band | SPS in codec_data |
|--------------+-------------+-------------------|
| avc          | maybe       | always            |
|--------------+-------------+-------------------|
| avc3         | always      | never             |
|--------------+-------------+-------------------|

Amendment 2 of ISO/IEC 14496-15 (AVC file format) is defining a new
structure for fragmented MP4 called "avc3". The principal difference
between AVC1 and AVC3 is the location of the codec initialisation
data (e.g. SPS, PPS). In AVC1 this data is placed in the initial MOOV box
(moov.trak.mdia.minf.stbl.stsd.avc1) but in AVC3 this data goes in the
first sample of every fragment.

https://bugzilla.gnome.org/show_bug.cgi?id=702004