### PR TITLE
Support passing a Java VM when initializing

### DIFF
--- a/gst-libs/gst/androidjni/gstjnisurface.c
+++ b/gst-libs/gst/androidjni/gstjnisurface.c
@@ -35,7 +35,7 @@ _cache_java_class (GstJniSurfaceClass * klass)
 {
   JNIEnv *env;
 
-  gst_jni_initialize ();
+  gst_jni_initialize (NULL);
 
   env = gst_jni_get_env ();
 

--- a/gst-libs/gst/androidjni/gstjnisurfacetexture.c
+++ b/gst-libs/gst/androidjni/gstjnisurfacetexture.c
@@ -38,7 +38,7 @@ _cache_java_class (GstJniSurfaceTextureClass * klass)
 {
   JNIEnv *env;
 
-  gst_jni_initialize ();
+  gst_jni_initialize (NULL);
   env = gst_jni_get_env ();
 
   klass->jklass = gst_jni_get_class (env, "android/graphics/SurfaceTexture");

--- a/gst-libs/gst/androidjni/gstjniutils.c
+++ b/gst-libs/gst/androidjni/gstjniutils.c
@@ -375,11 +375,16 @@ create_failed:
 }
 
 gboolean
-gst_jni_initialize (void)
+gst_jni_initialize (JavaVM * java_vm)
 {
   if (!__initialized) {
     pthread_key_create (&__current_jni_env, gst_jni_detach_current_thread);
-    __initialized = gst_jni_initialize_java_vm ();
+    if (!java_vm)
+      __initialized = gst_jni_initialize_java_vm ();
+    else {
+      __initialized = TRUE;
+      __java_vm = java_vm;
+    }
   }
   return __initialized;
 }

--- a/gst-libs/gst/androidjni/gstjniutils.h
+++ b/gst-libs/gst/androidjni/gstjniutils.h
@@ -53,7 +53,7 @@ gchar *gst_jni_string_to_gchar (JNIEnv * env, jstring string, gboolean release);
 
 jstring gst_jni_string_from_gchar (JNIEnv * env, const gchar * string);
 
-gboolean gst_jni_initialize (void);
+gboolean gst_jni_initialize (JavaVM * java_vm);
 
 gboolean gst_jni_is_vm_started (void);
 

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -2771,7 +2771,7 @@ plugin_init (GstPlugin * plugin)
 
   GST_DEBUG_CATEGORY_INIT (gst_amc_debug, "amc", 0, "android-media-codec");
 
-  if (!gst_jni_initialize ())
+  if (!gst_jni_initialize (NULL))
     return FALSE;
 
   gst_plugin_add_dependency_simple (plugin, NULL, "/etc", "media_codecs.xml",


### PR DESCRIPTION
This is needed for Android versions > 4.4 where there's no
public C API to create a VM. In this case the application
can safely pass the Java VM when initializing the JNI
library