### PR TITLE
Fix broken timestamps on interlaced output

### DIFF
--- a/sys/androidmedia/video/gstvideodecoder.h
+++ b/sys/androidmedia/video/gstvideodecoder.h
@@ -368,6 +368,9 @@ GstFlowReturn    gst_video_decoder_finish_frame (GstVideoDecoder *decoder,
 GstFlowReturn    gst_video_decoder_drop_frame (GstVideoDecoder *dec,
 					       GstVideoCodecFrame *frame);
 
+GstVideoCodecFrame *
+gst_video_decoder_get_output_frame (GstVideoDecoder * decoder, GstClockTime reference_timestamp);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
On interlaced content Hisilicon's decoder
outputs 2 times more buffers with 1/2 of
original duration. In this commit we're
changing strategy from trusting the
input timestamps to trusting timestamps
from the decoder.
Side-effect of patch is that
we can produce some frames "undroppable"
by the decoder.. But on other hand decoder
is not the one who drops frames, sink will
do that, isn't it?
This can be fixed easily, let's wait for
a good case to debug it.