### PR TITLE
amcvideodec: don't send eos on flow error

### DIFF
--- a/sys/androidmedia/gstamcvideodec.c
+++ b/sys/androidmedia/gstamcvideodec.c
@@ -1363,8 +1363,7 @@ error:
   /* We're going to stop srcpad's loop until new buffers on sinkpad */
 
   if (error_msg) {
-    GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL), ("### %s", error_msg));
-    gst_pad_push_event (GST_VIDEO_DECODER_SRC_PAD (self), gst_event_new_eos ());
+    GST_ELEMENT_ERROR (self, LIBRARY, FAILED, (NULL), ("%s", error_msg));
     self->downstream_flow_ret = GST_FLOW_ERROR;
   }
 


### PR DESCRIPTION
It was causing next deadlock:
gst_pad_push_event can never return, because
up the stack there will be a sink waiting
for a preroll that will never happen.
