### PR TITLE
Remove clearing to black on render thread termination

### DIFF
--- a/ext/eglgles/gsteglglessink.c
+++ b/ext/eglgles/gsteglglessink.c
@@ -344,11 +344,6 @@ render_thread_func (GstEglGlesSink * eglglessink)
 
   GST_DEBUG_OBJECT (eglglessink, "Shutting down thread");
 
-  /* Filling the surface with black color */
-  glClearColor (0.0, 0.0, 0.0, 1.0);
-  glClear (GL_COLOR_BUFFER_BIT);
-  gst_egl_adaptation_swap_buffers (eglglessink->egl_context);
-
   /* EGL/GLES cleanup */
   gst_eglglessink_cleanup (eglglessink);
 


### PR DESCRIPTION
Clearing to black was added to suit tests that expect a black screen when
stopping. But a stream deactivation also results in the sink going to ready and
destroyed, and doing it in a subtitles surface hiddens the video surface.

This would work if we could select the clearing colour with a property, so that
video is cleared to black and subtitles are cleared to transparent. But it
involves changes to basesink, all sinks, and fluendo-sdk, and will also involve
meaningful additional work if we change to gst 1.0.

For now, we have implemented the clearing in sraf-browser and we are reverting
the clearing in eglglessink.

We may want to decide a better platform independent approach in the future,
as the fix in sraf-browser only fixes the issue for sraf and is platform
dependent (android only).