### PR TITLE
amc: ignore OMX.MTK.AUDIO

### DIFF
--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -2045,7 +2045,8 @@ scan_codecs (GstPlugin * plugin)
       goto next_codec;
     }
 
-    if (g_str_has_prefix (name_str, "OMX.ARICENT.")) {
+    if (g_str_has_prefix (name_str, "OMX.ARICENT.")
+        || g_str_has_prefix (name_str, "OMX.MTK.AUDIO")) {
       GST_INFO ("Skipping possible broken codec '%s'", name_str);
       valid_codec = FALSE;
       goto next_codec;


### PR DESCRIPTION
OMX.MTK.AUDIO.DECODER.DSPAAC consumes data
without blocking that makes queue2 empty
at every moment.