### PR TITLE
openslessink: allow 48kHz audio rate

### DIFF
--- a/sys/opensles/openslessink.c
+++ b/sys/opensles/openslessink.c
@@ -53,12 +53,8 @@ enum
 #define DEFAULT_VOLUME 1.0
 #define DEFAULT_MUTE   FALSE
 
-
 /* According to Android's NDK doc the following are the supported rates */
-#define RATES "8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100"
-/* 48000 Hz is also claimed to be supported but the AudioFlinger downsampling
- * doesn't seems to work properly so we relay GStreamer audioresample element
- * to cope with this samplerate. */
+#define RATES "8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000"
 
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,


### PR DESCRIPTION
Seems that 48kHz was not supported well on
older versions of NDK and devices.
Currently on Android TVs for example system
upsamples 44100 Hz to 48000, so by downsampling
we only introduce performance loss.
Also following current documentation of NDK,
48kHz is supported.