### PR TITLE
amc/egl: smooth rendering of video frames

### DIFF
--- a/ext/eglgles/gstegladaptation.h
+++ b/ext/eglgles/gstegladaptation.h
@@ -184,7 +184,7 @@ gboolean gst_egl_adaptation_update_surface_dimensions (GstEglAdaptationContext *
 
 /* rendering */
 void gst_egl_adaptation_bind_API (GstEglAdaptationContext * ctx);
-gboolean gst_egl_adaptation_swap_buffers (GstEglAdaptationContext * ctx);
+gboolean gst_egl_adaptation_swap_buffers (GstEglAdaptationContext * ctx, GstClockTime ts);
 
 /* get/set */
 void gst_egl_adaptation_set_window (GstEglAdaptationContext * ctx, guintptr window);

--- a/ext/eglgles/gstegladaptation_egl.c
+++ b/ext/eglgles/gstegladaptation_egl.c
@@ -439,8 +439,20 @@ gst_egl_adaptation_bind_API (GstEglAdaptationContext * ctx)
 }
 
 gboolean
-gst_egl_adaptation_swap_buffers (GstEglAdaptationContext * ctx)
+gst_egl_adaptation_swap_buffers (GstEglAdaptationContext * ctx, GstClockTime ts)
 {
+#if HAVE_ANDROID
+  /* display at next ms */
+  if (G_LIKELY (GST_CLOCK_TIME_IS_VALID (ts))) {
+    if (G_UNLIKELY (!eglPresentationTimeANDROID (ctx->eglglesctx->display,
+                ctx->eglglesctx->surface, ts)))
+      GST_DEBUG_OBJECT (ctx->element,
+          "eglPresentationTimeANDROID (%" G_GINT64_FORMAT ") failed", ts);
+  }
+#else
+  (void) ts;
+#endif
+
   gboolean ret =
       eglSwapBuffers (ctx->eglglesctx->display, ctx->eglglesctx->surface);
   if (ret == EGL_FALSE) {

--- a/ext/eglgles/gsteglglessink.c
+++ b/ext/eglgles/gsteglglessink.c
@@ -986,9 +986,8 @@ gst_eglglessink_upload (GstEglGlesSink * eglglessink, GstBuffer * buf)
             (eglglessink->surface_texture,
             eglglessink->egl_context->texture[0]);
       }
-      if (!gst_jni_amc_direct_buffer_render (drbuf)) {
-        return GST_FLOW_CUSTOM_ERROR;
-      }
+
+      /* FIXME: in fact we should wait for onFrameAvailable before updating the texture */
       gst_jni_surface_texture_update_tex_image (eglglessink->surface_texture);
     }
   } else {
@@ -1098,6 +1097,24 @@ gst_eglglessink_render (GstEglGlesSink * eglglessink, GstBuffer * buf)
   guint dar_n, dar_d;
   gint i;
   gint w, h;
+  GstClockTime render_ts = GST_CLOCK_TIME_NONE;
+
+#if HAVE_ANDROID
+  gint64 swap_time;
+  gint64 wakeup = g_get_monotonic_time () * 1000;
+  GstClockTime base_time =
+      gst_element_get_base_time (GST_ELEMENT (eglglessink));
+  GstClockTime buffer_ts =
+      gst_segment_to_running_time (&GST_BASE_SINK (eglglessink)->segment,
+      GST_FORMAT_TIME, GST_BUFFER_TIMESTAMP (buf));
+
+  /* Calculate the timestamp we'll attach to the surface
+   * before calling eglSwapBuffers. But not in preroll,
+   * only if we're playing */
+  if (eglglessink->playing) {
+    render_ts = buffer_ts + base_time;
+  }
+#endif
 
   g_rec_mutex_lock (&eglglessink->window_lock);
 
@@ -1279,9 +1296,21 @@ gst_eglglessink_render (GstEglGlesSink * eglglessink, GstBuffer * buf)
   if (got_gl_error ("glDrawElements"))
     goto HANDLE_ERROR;
 
-  if (!gst_egl_adaptation_swap_buffers (eglglessink->egl_context)) {
+#if HAVE_ANDROID
+  if (__gst_debug_min >= GST_LEVEL_LOG)
+    swap_time = g_get_monotonic_time () * 1000;
+#endif
+
+  if (!gst_egl_adaptation_swap_buffers (eglglessink->egl_context, render_ts)) {
     goto HANDLE_ERROR;
   }
+#if HAVE_ANDROID
+  GST_LOG_OBJECT (eglglessink, "Swapped buffers at %" G_GINT64_FORMAT
+      " , render ts = %" G_GUINT64_FORMAT
+      " , base_time = %" G_GUINT64_FORMAT
+      " , woke up at %" G_GINT64_FORMAT,
+      swap_time, render_ts, base_time, wakeup);
+#endif
 
   GST_DEBUG_OBJECT (eglglessink, "Succesfully rendered 1 frame");
   g_rec_mutex_unlock (&eglglessink->window_lock);
@@ -1389,6 +1418,14 @@ gst_eglglessink_configure_caps (GstEglGlesSink * eglglessink, GstCaps * caps)
 
   gst_caps_replace (&eglglessink->configured_caps, caps);
 
+#if HAVE_ANDROID
+  /* We tell sink to wake up 50ms before the image is expected
+   * to be shown on a screen. This value is 50ms because it's 2 VSYNC periods + 10ms.
+   * In fact it had been derived empirically. */
+  gst_base_sink_set_ts_offset (GST_BASE_SINK (eglglessink),
+      G_GINT64_CONSTANT (-50000000));
+#endif
+
 SUCCEED:
   gst_eglglessink_generate_rotation (eglglessink);
   GST_INFO_OBJECT (eglglessink, "Configured caps successfully");
@@ -1458,6 +1495,14 @@ gst_eglglessink_change_state (GstElement * element, GstStateChange transition)
         goto done;
       }
       break;
+#if HAVE_ANDROID
+    case GST_STATE_CHANGE_PAUSED_TO_PLAYING:
+      eglglessink->playing = TRUE;
+      break;
+    case GST_STATE_CHANGE_PLAYING_TO_PAUSED:
+      eglglessink->playing = FALSE;
+      break;
+#endif
     default:
       break;
   }

--- a/ext/eglgles/gsteglglessink.h
+++ b/ext/eglgles/gsteglglessink.h
@@ -137,6 +137,7 @@ struct _GstEglGlesSink
 
 #ifdef HAVE_ANDROID_MEDIA
   GstJniSurfaceTexture *surface_texture;
+  volatile gboolean playing;
 #endif
 
   /* Needed for requesting a window while playing */

--- a/ext/eglgles/video_platform_wrapper.h
+++ b/ext/eglgles/video_platform_wrapper.h
@@ -53,6 +53,10 @@
 #include <gst/gst.h>
 #include <EGL/egl.h>
 
+#if HAVE_ANDROID
+#include <EGL/eglext.h>
+#endif
+
 gboolean platform_wrapper_init (void);
 EGLNativeWindowType platform_create_native_window (gint width, gint height, gpointer * window_data);
 gboolean platform_destroy_native_window (EGLNativeDisplayType display,

--- a/gst-libs/gst/androidjni/gstjniamcdirectbuffer.h
+++ b/gst-libs/gst/androidjni/gstjniamcdirectbuffer.h
@@ -33,13 +33,15 @@ struct _GstJniAmcDirectBuffer {
   GstJniSurfaceTexture *texture;
   jobject media_codec;
   jmethodID release_output_buffer;
+  jmethodID release_output_buffer_ts;
   guint idx;
   gboolean released;
 };
 
 GstJniAmcDirectBuffer * gst_jni_amc_direct_buffer_new (
     GstJniSurfaceTexture *texture, jobject media_codec,
-    jmethodID release_output_buffer, guint idx);
+    jmethodID release_output_buffer, jmethodID release_output_buffer_ts,
+    guint idx);
 
 GstJniAmcDirectBuffer * gst_jni_amc_direct_buffer_from_gst_buffer (GstBuffer *buf);
 

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -81,6 +81,7 @@ static struct
   jmethodID queue_input_buffer;
   jmethodID release;
   jmethodID release_output_buffer;
+  jmethodID release_output_buffer_ts;
   jmethodID start;
   jmethodID stop;
   jint CRYPTO_MODE_AES_CTR;
@@ -637,6 +638,12 @@ gst_amc_codec_free (GstAmcCodec * codec, GstAmcCrypto * crypto_ctx)
 
   J_DELETE_GLOBAL_REF (codec->object);
   g_slice_free (GstAmcCodec, codec);
+}
+
+jmethodID
+gst_amc_codec_get_release_ts_method_id (GstAmcCodec * codec)
+{
+  return media_codec.release_output_buffer_ts;
 }
 
 jmethodID
@@ -1430,6 +1437,9 @@ get_java_classes (void)
   media_codec.release_output_buffer =
       (*env)->GetMethodID (env, media_codec.klass, "releaseOutputBuffer",
       "(IZ)V");
+  media_codec.release_output_buffer_ts =
+      (*env)->GetMethodID (env, media_codec.klass, "releaseOutputBuffer",
+      "(IJ)V");
   media_codec.start =
       (*env)->GetMethodID (env, media_codec.klass, "start", "()V");
   media_codec.stop =
@@ -1447,6 +1457,7 @@ get_java_classes (void)
       media_codec.queue_input_buffer &&
       media_codec.release &&
       media_codec.release_output_buffer &&
+      media_codec.release_output_buffer_ts &&
       media_codec.start && media_codec.stop);
 
   tmp = (*env)->FindClass (env, "android/media/MediaCodec$BufferInfo");

--- a/sys/androidmedia/gstamc.h
+++ b/sys/androidmedia/gstamc.h
@@ -100,6 +100,7 @@ GstAmcCodec *gst_amc_codec_new (const gchar * name);
 void gst_amc_codec_free (GstAmcCodec * codec, GstAmcCrypto * crypto_ctx);
 
 jmethodID gst_amc_codec_get_release_method_id (GstAmcCodec * codec);
+jmethodID gst_amc_codec_get_release_ts_method_id (GstAmcCodec * codec);
 gboolean gst_amc_codec_configure (GstAmcCodec * codec, GstAmcFormat * format,
     guint8 * surface, jobject mcrypto_obj, gint flags);
 GstAmcFormat *gst_amc_codec_get_output_format (GstAmcCodec * codec);

--- a/sys/androidmedia/gstamcaudiodec.c
+++ b/sys/androidmedia/gstamcaudiodec.c
@@ -371,7 +371,7 @@ gst_amc_audio_dec_set_property (GObject * object, guint prop_id,
 }
 
 static gboolean
-gst_amc_audio_dec_event (GstAudioDecoder *dec, GstEvent *event)
+gst_amc_audio_dec_event (GstAudioDecoder * dec, GstEvent * event)
 {
   gboolean handled = FALSE;
 
@@ -1355,9 +1355,9 @@ gst_amc_audio_dec_drain (GstAmcAudioDec * self)
     buffer_info.flags |= BUFFER_FLAG_END_OF_STREAM;
 
     if (gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info)) {
-      GST_ERROR_OBJECT (self, ";;; Waiting until codec is drained");
+      GST_DEBUG_OBJECT (self, "Waiting until codec is drained");
       g_cond_wait (self->drain_cond, self->drain_lock);
-      GST_ERROR_OBJECT (self, ";;; Drained codec");
+      GST_DEBUG_OBJECT (self, "Drained codec");
       ret = GST_FLOW_OK;
     } else {
       GST_ERROR_OBJECT (self, "Failed to queue input buffer");


### PR DESCRIPTION
This code tries not to loose VSYNC on android.
To make it possible we follow next ideas:
- call releaseOutputBuffer immediatelly, so it
won't be dropped by SurfaceFlinger. Drops were
really happening before.
- set presentation timestamp for surface we're
going to render before eglSwapBuffers.
- timestamp is calculated to moment at which buffer
should be rendered in system time.
- sink must wake up and "enqueue" surface with
eglSwapBuffers at least ~20ms before the moment
at which buffer should be rendered

NOTE: this solution plays smooth only if
application uses SurfaceView.