### PR TITLE
eglglessink: allow user to provide window late

### DIFF
--- a/ext/eglgles/gsteglglessink.c
+++ b/ext/eglgles/gsteglglessink.c
@@ -379,8 +379,8 @@ gst_eglglessink_start (GstEglGlesSink * eglglessink)
   if (!gst_eglglessink_request_window (eglglessink) &&
       !eglglessink->create_window) {
     GST_ERROR_OBJECT (eglglessink, "Window handle unavailable and we "
-        "were instructed not to create an internal one. Bailing out.");
-    goto HANDLE_ERROR;
+        "were instructed not to create an internal one. "
+        "Nothing will be rendered until window is provided.");
   }
 
   eglglessink->last_flow = GST_FLOW_OK;
@@ -1119,8 +1119,24 @@ gst_eglglessink_render (GstEglGlesSink * eglglessink, GstBuffer * buf)
 
   gst_eglglessink_transform_size (eglglessink, &w, &h);
 
-  if (!gst_eglglessink_request_or_create_window (eglglessink, w, h)) {
-    goto HANDLE_ERROR;
+  /* We query the window from user, but if there's no window - first we retry, then
+   * if still no window - we just skip this frame */
+  for (i = 0; i < 2; i++) {
+    if (G_LIKELY (gst_eglglessink_request_or_create_window (eglglessink, w, h))) {
+      break;
+    } else {
+      GST_ERROR_OBJECT (eglglessink,
+          "No window to render frame at %" GST_TIME_FORMAT " , %s",
+          GST_TIME_ARGS (GST_BUFFER_TIMESTAMP (buf)),
+          i < 1 ? "retrying after 10 ms.." : "do nothing");
+      if (i < 1) {
+        g_usleep (10000);
+        continue;
+      } else {
+        g_rec_mutex_unlock (&eglglessink->window_lock);
+        return GST_FLOW_OK;
+      }
+    }
   }
 
   /* Upload the buffer if we need to */

--- a/sys/androidmedia/gstamcaudiodec.c
+++ b/sys/androidmedia/gstamcaudiodec.c
@@ -371,7 +371,7 @@ gst_amc_audio_dec_set_property (GObject * object, guint prop_id,
 }
 
 static gboolean
-gst_amc_audio_dec_event (GstAudioDecoder *dec, GstEvent *event)
+gst_amc_audio_dec_event (GstAudioDecoder * dec, GstEvent * event)
 {
   gboolean handled = FALSE;
 
@@ -1355,9 +1355,9 @@ gst_amc_audio_dec_drain (GstAmcAudioDec * self)
     buffer_info.flags |= BUFFER_FLAG_END_OF_STREAM;
 
     if (gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info)) {
-      GST_ERROR_OBJECT (self, ";;; Waiting until codec is drained");
+      GST_DEBUG_OBJECT (self, "Waiting until codec is drained");
       g_cond_wait (self->drain_cond, self->drain_lock);
-      GST_ERROR_OBJECT (self, ";;; Drained codec");
+      GST_DEBUG_OBJECT (self, "Drained codec");
       ret = GST_FLOW_OK;
     } else {
       GST_ERROR_OBJECT (self, "Failed to queue input buffer");


### PR DESCRIPTION
Now if we are going to render and no window is
provided still, we're just going to complain in
the logs, but not refusing the work at all.
So if user wasn't lucky at some moment, even if
it was a user's fault, we can recover.