### PR TITLE
Hs 3012

### DIFF
--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -707,6 +707,8 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
     goto error;
   }
 
+  jtmpstr = (*env)->NewStringUTF (env, mime);
+
   get_capabilities_for_type_id =
       (*env)->GetMethodID (env, codec_info_class, "getCapabilitiesForType",
       "(Ljava/lang/String;)Landroid/media/MediaCodecInfo$CodecCapabilities;");
@@ -718,11 +720,16 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
 
   capabilities =
       (*env)->CallObjectMethod (env, codec_info, get_capabilities_for_type_id,
-      mime);
+      jtmpstr);
   if ((*env)->ExceptionCheck (env)) {
     (*env)->ExceptionClear (env);
     GST_ERROR ("Failed to get capabilities for %s", mime);
     goto error;
+  }
+
+  if (jtmpstr != NULL) {
+    J_DELETE_LOCAL_REF (jtmpstr);
+    jtmpstr = NULL;
   }
 
   capabilities_class = (*env)->GetObjectClass (env, capabilities);

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -753,6 +753,8 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   }
 
   if (adaptivePlaybackSupported) {
+    int width = 0;
+    int height = 0;
     jclass media_format_class = NULL;
     jmethodID enable_feature_id;
 
@@ -771,15 +773,13 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
       (*env)->ExceptionClear (env);
       goto error;
     }
-    int width = 0;
-    int height = 0;
+
     gst_amc_format_get_int (format, "width", &width);
     gst_amc_format_get_int (format, "height", &height);
 
-
     (*env)->CallVoidMethod (env, format->object, enable_feature_id, jtmpstr, 1);
 
-    GST_ERROR ("Setting max-width = %d max-height = %d", width, height);
+    GST_LOG ("Setting max-width = %d max-height = %d", width, height);
     gst_amc_format_set_int (format, "max-width", width);
     gst_amc_format_set_int (format, "max-height", height);
     gst_amc_format_set_int (format, "adaptive-playback", 1);

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -669,6 +669,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   jclass capabilities_class = NULL;
   jstring jtmpstr = NULL;
 
+  GST_DEBUG ("Calling gst_amc_codec_enable_adaptive_playback()");
   JNIEnv *env = gst_jni_get_env ();
 
   media_codec_class = (*env)->GetObjectClass (env, codec->object);
@@ -774,7 +775,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
 
     enable_feature_id =
         (*env)->GetMethodID (env, media_format_class, "setFeatureEnabled",
-        "(Ljava/lang/String;Z)");
+        "(Ljava/lang/String;Z)V");
     if (!enable_feature_id) {
       GST_ERROR ("Can't get method setFeatureEnabled");
       (*env)->ExceptionClear (env);
@@ -786,16 +787,22 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
 
     (*env)->CallVoidMethod (env, format->object, enable_feature_id, jtmpstr, 1);
 
-    GST_LOG ("Setting max-width = %d max-height = %d", width, height);
+    GST_DEBUG ("Setting max-width = %d max-height = %d", width, height);
     gst_amc_format_set_int (format, "max-width", width);
     gst_amc_format_set_int (format, "max-height", height);
     gst_amc_format_set_int (format, "adaptive-playback", 1);
   }
 
 error:
-  if (jtmpstr != NULL)
-    J_DELETE_LOCAL_REF (jtmpstr);
+  J_DELETE_LOCAL_REF (jtmpstr);
   g_free (mime);
+
+  J_DELETE_LOCAL_REF (codec_info_class);
+  J_DELETE_LOCAL_REF (media_codec_class);
+  J_DELETE_LOCAL_REF (capabilities_class);
+  J_DELETE_LOCAL_REF (capabilities);
+  GST_DEBUG ("Feature adaptive-playback %ssupported",
+      (!adaptivePlaybackSupported) ? "not " : "");
   return adaptivePlaybackSupported;
 }
 

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -752,15 +752,11 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
     goto error;
   }
 
-  GST_ERROR ("&&& Codec %s: adaptive-playback %ssupported", mime,
-      adaptivePlaybackSupported ? "" : "not ");
-
   if (adaptivePlaybackSupported) {
     int width = 0;
     int height = 0;
     gst_amc_format_get_int (format, "width", &width);
     gst_amc_format_get_int (format, "height", &height);
-    GST_ERROR ("TEST WIDTH=%d HEIGHT =%d", width, height);
 
     GST_ERROR ("Setting max-width = %d max-height = %d", width, height);
     gst_amc_format_set_int (format, "max-width", width);
@@ -787,38 +783,7 @@ gst_amc_codec_configure (GstAmcCodec * codec, GstAmcFormat * format,
     GST_ERROR ("{{{ configuring with MCrypto [%p]", mcrypto_obj);
     AMC_CHK ((*env)->IsInstanceOf (env, mcrypto_obj, media_crypto.klass));
   }
-/*
-  jclass tmp;
-  jmethodID set_integer_id;
-  jmethodID get_integer_id;
-  jclass tmp = (*env)->FindClass (env, "android/media/MediaFormat");
-  if (!tmp) {
-    ret = FALSE;
-    (*env)->ExceptionClear (env);
-    GST_ERROR ("Failed to get format class");
-    goto error;
-  }
 
-  get_integer_id =
-      (*env)->GetMethodID (env, tmp, "getInteger",
-      "(Ljava/lang/String;)I");
-
-  set_integer_id =
-      (*env)->GetMethodID (env, tmp, "setInteger",
-      "(Ljava/lang/String;I)V");
-      
-  format.setInteger(MediaFormat.KEY_MAX_WIDTH, 1920);
-  format.setInteger(MediaFormat.KEY_MAX_HEIGHT, 1080);
-*/
-
-/*
-
-  MediaCodecInfo info = aCodec.getCodecInfo();
-  MediaCodecInfo.CodecCapabilities capabilities = info.getCapabilitiesForType(aMimeType);
-  return capabilities != null &&
-          capabilities.isFeatureSupported(
-              MediaCodecInfo.CodecCapabilities.FEATURE_AdaptivePlayback);
-*/
   gst_amc_codec_enable_adaptive_playback (codec, format);
   J_CALL_VOID (codec->object, media_codec.configure,
       format->object, surface, mcrypto_obj, flags);

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -660,6 +660,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
 {
   gboolean adaptivePlaybackSupported = FALSE;
   jclass codec_info_class = NULL;
+  jclass media_codec_class = NULL;
   jobject capabilities = NULL;
   jmethodID get_codec_info_id;
   jmethodID get_capabilities_for_type_id;
@@ -669,8 +670,16 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   jstring jtmpstr = NULL;
 
   JNIEnv *env = gst_jni_get_env ();
+
+  media_codec_class = (*env)->GetObjectClass (env, codec->object);
+  if ((*env)->ExceptionCheck (env)) {
+    (*env)->ExceptionClear (env);
+    GST_ERROR ("Failed to get media_codec class");
+    goto error;
+  }
+
   get_codec_info_id =
-      (*env)->GetStaticMethodID (env, codec->object, "getCodecInfo",
+      (*env)->GetStaticMethodID (env, media_codec_class, "getCodecInfo",
       "()Landroid/media/MediaCodecInfo;");
   if ((*env)->ExceptionCheck (env)) {
     (*env)->ExceptionClear (env);

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -681,7 +681,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   get_codec_info_id =
       (*env)->GetStaticMethodID (env, media_codec_class, "getCodecInfo",
       "()Landroid/media/MediaCodecInfo;");
-  if ((*env)->ExceptionCheck (env)) {
+  if (!get_codec_info_id) {
     (*env)->ExceptionClear (env);
     GST_ERROR ("Failed to get get_codec_info_id method");
     goto error;
@@ -710,6 +710,11 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   get_capabilities_for_type_id =
       (*env)->GetMethodID (env, codec_info_class, "getCapabilitiesForType",
       "(Ljava/lang/String;)Landroid/media/MediaCodecInfo$CodecCapabilities;");
+  if (!get_capabilities_for_type_id) {
+    (*env)->ExceptionClear (env);
+    GST_ERROR ("Failed to get get_capabilities_for_type_id method");
+    goto error;
+  }
 
   capabilities =
       (*env)->CallObjectMethod (env, codec_info, get_capabilities_for_type_id,
@@ -721,7 +726,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   }
 
   capabilities_class = (*env)->GetObjectClass (env, capabilities);
-  if (!capabilities_class) {
+  if ((*env)->ExceptionCheck (env)) {
     (*env)->ExceptionClear (env);
     GST_ERROR ("Failed to get capabilities class");
     goto error;
@@ -730,7 +735,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   is_feature_supported_id =
       (*env)->GetMethodID (env, capabilities_class, "isFeatureSupported",
       "(Ljava/lang/String;)Z");
-  if ((*env)->ExceptionCheck (env)) {
+  if (!is_feature_supported_id) {
     (*env)->ExceptionClear (env);
     GST_ERROR ("Failed to get isFeatureSupported method");
     goto error;

--- a/sys/androidmedia/gstamc.c
+++ b/sys/androidmedia/gstamc.c
@@ -679,7 +679,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   }
 
   get_codec_info_id =
-      (*env)->GetStaticMethodID (env, media_codec_class, "getCodecInfo",
+      (*env)->GetMethodID (env, media_codec_class, "getCodecInfo",
       "()Landroid/media/MediaCodecInfo;");
   if (!get_codec_info_id) {
     (*env)->ExceptionClear (env);
@@ -688,7 +688,7 @@ gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec,
   }
 
   jobject codec_info =
-      (*env)->CallStaticObjectMethod (env, codec->object, get_codec_info_id);
+      (*env)->CallObjectMethod (env, codec->object, get_codec_info_id);
   if ((*env)->ExceptionCheck (env)) {
     (*env)->ExceptionClear (env);
     GST_ERROR ("Failed to get MediaCodecInfo from codec");

--- a/sys/androidmedia/gstamc.h
+++ b/sys/androidmedia/gstamc.h
@@ -218,6 +218,7 @@ gboolean gst_amc_query_set_surface (GstQuery *query, gpointer surface);
 GstEvent * gst_amc_event_new_surface (gpointer surface);
 gpointer gst_amc_event_parse_surface (GstEvent *event);
 gboolean gst_amc_event_is_surface (GstEvent *event);
+gboolean gst_amc_codec_enable_adaptive_playback (GstAmcCodec * codec, GstAmcFormat * format);
 
 G_END_DECLS
 #endif /* __GST_AMC_H__ */


### PR DESCRIPTION
Before configuring amc codec we check if adaptive-playback feature is available. Using the following sequence: MediaCodec -> MediaCodecInfo -> CodecCapabilites -> isFeatureAvailable().
If we have this feature we enable it and set max-width /max-height using the current width/height values, it will keep restarting the codec if resolution changes but we will use a different video layer to render video.