### PR TITLE
amc/drm: fix failure on first drm event

### DIFF
--- a/sys/androidmedia/gstamc.h
+++ b/sys/androidmedia/gstamc.h
@@ -120,11 +120,9 @@ gint gst_amc_codec_dequeue_input_buffer (GstAmcCodec * codec, gint64 timeoutUs);
 gint gst_amc_codec_dequeue_output_buffer (GstAmcCodec * codec,
     GstAmcBufferInfo * info, gint64 timeoutUs);
 
-gboolean gst_amc_codec_queue_secure_input_buffer (GstAmcCodec * codec,
-    gint index, const GstAmcBufferInfo * info, const GstBuffer * drmbuf);
-
 gboolean gst_amc_codec_queue_input_buffer (GstAmcCodec * codec, gint index,
-    const GstAmcBufferInfo * info);
+    const GstAmcBufferInfo * info, const GstBuffer * drmbuf,
+    GstAmcCrypto * drmctx);
 gboolean gst_amc_codec_release_output_buffer (GstAmcCodec * codec, gint index);
 gboolean gst_amc_codec_render_output_buffer (GstAmcCodec * codec, gint index,
     GstClockTime ts);

--- a/sys/androidmedia/gstamcdrm.c
+++ b/sys/androidmedia/gstamcdrm.c
@@ -809,8 +809,9 @@ gst_amc_drm_handle_drm_event (GstAmcCrypto * ctx, GstEvent * event)
         "User didn't provide us MediaCrypto, trying In-band mode");
     if (!gst_amc_drm_jmedia_crypto_from_pssh (ctx, init_data, init_data_size,
             system_id)) {
-      GST_ELEMENT_ERROR (el, LIBRARY, FAILED, (NULL),
-          ("In-band mode's drm event proccessing failed"));
+      GST_INFO_OBJECT (el, "In-band mode's drm event proccessing failed");
+      /* This is not a true error situation, there might be more drm events with
+       * other systemIds */
     }
   }
 

--- a/sys/androidmedia/gstamcvideodec.c
+++ b/sys/androidmedia/gstamcvideodec.c
@@ -1810,10 +1810,9 @@ gst_amc_video_dec_handle_frame (GstVideoDecoder * decoder,
         " flags 0x%08x", idx, buffer_info.size,
         buffer_info.presentation_time_us, buffer_info.flags);
 
-    queued_input_buffer = self->drm_ctx ?
-        gst_amc_codec_queue_secure_input_buffer (self->codec, idx,
-        &buffer_info, frame->input_buffer)
-        : gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info);
+    queued_input_buffer =
+        gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info,
+        frame->input_buffer, self->drm_ctx);
 
     CHK (queued_input_buffer);
 
@@ -1894,7 +1893,8 @@ gst_amc_video_dec_eos (GstVideoDecoder * decoder)
        if for some reason the task is going to stop..
      */
     g_mutex_lock (self->drain_lock);
-    if (gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info)) {
+    if (gst_amc_codec_queue_input_buffer (self->codec, idx, &buffer_info, NULL,
+            self->drm_ctx)) {
       GST_ERROR_OBJECT (self, "Waiting until codec is drained");
 
       self->drain_cond_signalling = FALSE;


### PR DESCRIPTION
If first drm event couldn't be procceed,
we don't treat it as an error, because there
may be more drm events from other systems.
To keep checking the sanity of the proccess,
we check MediaCrypto presence on input of media.