### PR TITLE
amc/tunneled: don't push dummy buffer

### DIFF
--- a/sys/androidmedia/gstamcvideodec.h
+++ b/sys/androidmedia/gstamcvideodec.h
@@ -100,8 +100,6 @@ struct _GstAmcVideoDec
   gboolean inband_drm_enabled;
   gboolean srcpad_loop_started;
   gint cached_input_buffer;
-
-  GstCaps *x_amc_empty_caps;
 };
 
 struct _GstAmcVideoDecClass


### PR DESCRIPTION
we don't need it anymore since we set up
the sink to be non-async