### PR TITLE
amcvideosink: drop first buffer if it's dummy

### DIFF
--- a/sys/androidmedia/gstamcvideosink.h
+++ b/sys/androidmedia/gstamcvideosink.h
@@ -74,6 +74,7 @@ struct _GstAmcVideoSink
 
   guint * surface;              /* Pointer the java Surface object */
   volatile gboolean playing;
+  GstPadChainFunction base_chain;
 };
 
 struct _GstAmcVideoSinkClass


### PR DESCRIPTION
First dummy buffer is pushed by amcvideodec when
it's going to configure MediaCodec, and is needed
only to make the pipeline create and plug
amcvideosink.

If we don't drop it, it causes some side effects,
such as preroll with dummy buffer and a warning
message from basesink, because of a buffer
being received before the newsegment event.